### PR TITLE
Add auth headers configuration by profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,18 @@ for the desired profile or for all the profiles.
     'token_path' => 'token',
 ],
 ```
+You can configure the authentication settings for the desired profile by adding the auth array in the profile config.
+
+```php
+'profiles' => [
+    'demo' => [
+        ...,
+        'auth' => [ // Add this section for custom auth settings
+            // Authentication settings specific to this profile
+        ],
+    ],
+],
+```
 If for some reason you don't want to include authentication while sending some request, you can tell the PConnector like so:
 ```php
 use MedianetDev\PConnector\Facade\PConnector;

--- a/src/AuthManager.php
+++ b/src/AuthManager.php
@@ -139,7 +139,7 @@ class AuthManager
             strtoupper(config('p-connector.profiles.'.$profile.'.auth.login_http_method', config('p-connector.auth.login_http_method', 'POST'))),
             $profile,
             false,
-            config('p-connector.auth.headers', []),
+            config('p-connector.profiles.'.$profile.'.auth.headers', config('p-connector.auth.headers', [])),
         );
 
         if ($result['status'] && in_array($result['response']['status_code'], config('p-connector.profiles.'.$profile.'.auth.success_login_code', config('p-connector.auth.success_login_code', [])))) {


### PR DESCRIPTION
We can configure the authentication settings for the desired profile by adding the auth array in the profile config.
