### PR TITLE
Add SSL verification configuration to request payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,9 @@ $demo = PConnector::profile('demo')->withoutAuth()->get('posts/1');
     'timeout' => 3,
     // The data type; json, form-data, ...
     'post_data' => 'json',
+
+    // Verify the SSL certificate or not
+    'verify' => true,
 ],
 ```
 ##### Localization

--- a/config/config.php
+++ b/config/config.php
@@ -66,6 +66,9 @@ return [
         'timeout' => 3,
         // The data type; json, form-data, ...
         'post_data' => 'json',
+
+        // Verify the SSL certificate or not
+        'verify' => true,
     ],
     // Log requests & responses to log files or not (you can make an exception with withLog() and withoutLog() methods)
     'log' => false, // [AAPS]

--- a/src/Concerns/Configurations.php
+++ b/src/Concerns/Configurations.php
@@ -78,7 +78,7 @@ trait Configurations
      * @param  string  $locale  [optional] The locale will default to the app.locale if not provided
      * @return \MedianetDev\PConnector\PConnector
      */
-    public function lang(string $locale = null)
+    public function lang(?string $locale = null)
     {
         $this->withHeader('Accept-Language', $locale ?? app()->getLocale());
 

--- a/src/Http/Base/BaseHttp.php
+++ b/src/Http/Base/BaseHttp.php
@@ -50,5 +50,5 @@ abstract class BaseHttp implements Http
      * @param  string  $errorMessage
      * @return array
      */
-    abstract protected function parser(string $url, string $method, array $payload, $response, bool $status = true, string $errorMessage = null): array;
+    abstract protected function parser(string $url, string $method, array $payload, $response, bool $status = true, ?string $errorMessage = null): array;
 }

--- a/src/Http/Guzzle.php
+++ b/src/Http/Guzzle.php
@@ -161,6 +161,10 @@ class Guzzle extends BaseHttp
             'p-connector.profiles.'.$profile.'.request.timeout',
             config('p-connector.request.timeout', 3)
         );
+        $payload['verify'] = config(
+            'p-connector.profiles.'.$profile.'.request.verify',
+            config('p-connector.request.verify', true)
+        );
 
         return $payload;
     }

--- a/src/Http/Guzzle.php
+++ b/src/Http/Guzzle.php
@@ -104,7 +104,7 @@ class Guzzle extends BaseHttp
         }
     }
 
-    protected function parser(string $url, string $method, array $payload, $response, bool $status = true, string $errorMessage = null): array
+    protected function parser(string $url, string $method, array $payload, $response, bool $status = true, ?string $errorMessage = null): array
     {
         $result['status'] = $status;
         $result['request'] = [

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -34,7 +34,7 @@ if (! function_exists('build_url')) {
      * @param  string  $url  The new url
      * @return string
      */
-    function build_url(string $path, string $profile, string $url = null): string
+    function build_url(string $path, string $profile, ?string $url = null): string
     {
         return (string) (
             $url ? (endsWith($url, '/') ? $url : ($path != '' ? $url.'/' : $url)) : config('p-connector.profiles.'.$profile.'.protocol', 'http')


### PR DESCRIPTION
Implemented a new parameter named 'verify' to allow for SSL verification configuration within the request payload. 

This enhancement increases the flexibility and security of the package by enabling users to customize SSL verification settings for their HTTP requests.